### PR TITLE
Fix integration with MD body master

### DIFF
--- a/PenumbraShadowMD.ino
+++ b/PenumbraShadowMD.ino
@@ -837,8 +837,8 @@ void setup()
 
 void sendMarcCommand(const char* cmd)
 {
-    SHADOW_VERBOSE("Sending MARC: \"%s\"\n", cmd)
-    MD_SERIAL.print(cmd); MD_SERIAL.print("\n");
+    SHADOW_VERBOSE("Sending MARC: \"%s\"\r", cmd)
+    MD_SERIAL.print(cmd); MD_SERIAL.print("\r");
 #if defined(MARC_SOUND_PLAYER)
     sMarcSound.handleCommand(cmd);
 #endif
@@ -846,8 +846,8 @@ void sendMarcCommand(const char* cmd)
 
 void sendBodyMarcCommand(const char* cmd)
 {
-    SHADOW_VERBOSE("Sending BODYMARC: \"%s\"\n", cmd)
-    BODY_MD_SERIAL.print(cmd); BODY_MD_SERIAL.print("\n");
+    SHADOW_VERBOSE("Sending BODYMARC: \"%s\"\r", cmd)
+    BODY_MD_SERIAL.print(cmd); BODY_MD_SERIAL.print("\r");
 }
 
 ////////////////////////////////

--- a/pin-map.h
+++ b/pin-map.h
@@ -12,8 +12,8 @@
 
 #define RXD1_PIN                33
 #define TXD1_PIN                25
-#define RXD2_PIN                16
-#define TXD2_PIN                17
+#define RXD2_PIN                17
+#define TXD2_PIN                16
 #define RXD3_PIN                32
 #define TXD3_PIN                4
 


### PR DESCRIPTION
- Switch RX/TX pins on serial #3

The TX pin appears to not be working; as this serial port is used for the body Marcduino we only need TX and so can switch the TX and RX pins. You will need to plug the MD into the yellow header instead of blue.

- Terminate MD commands with \r

Marcduino expects commands to be terminated with a carriage return rather than newline.